### PR TITLE
add _Coroutine checks to CodeCompletion test

### DIFF
--- a/clang/test/CodeCompletion/ordinary-name-cxx11.cpp
+++ b/clang/test/CodeCompletion/ordinary-name-cxx11.cpp
@@ -5,6 +5,7 @@ typedef struct t TYPEDEF;
 void foo() {
   int y = 17;
   // RUN: %clang_cc1 -fsyntax-only -fcxx-exceptions -code-completion-patterns -code-completion-at=%s:6:14 -std=gnu++11 %s -o - | FileCheck -check-prefix=CHECK-CC1 %s
+  // CHECK-CC1: COMPLETION: Pattern : _Coroutine [#A Coroutine, as defined by concurrency course.#]typename <#name#>
   // CHECK-CC1: COMPLETION: bool
   // CHECK-CC1-NEXT: COMPLETION: char
   // CHECK-CC1-NEXT: COMPLETION: char16
@@ -57,7 +58,6 @@ void foo() {
   // CHECK-CC1: COMPLETION: TYPEDEF : TYPEDEF
   // CHECK-CC1-NEXT: COMPLETION: Pattern : typedef <#type#> <#name#>;
   // CHECK-CC1-NEXT: COMPLETION: Pattern : [#std::type_info#]typeid(<#expression-or-type#>)
-  // CHECK-CC1-NEXT: COMPLETION: Pattern : typename <#name#>
   // CHECK-CC1-NEXT: COMPLETION: Pattern : typeof <#expression#>
   // CHECK-CC1-NEXT: COMPLETION: Pattern : typeof(<#type#>)
   // CHECK-CC1-NEXT: COMPLETION: union

--- a/clang/test/CodeCompletion/ordinary-name-cxx11.cpp
+++ b/clang/test/CodeCompletion/ordinary-name-cxx11.cpp
@@ -75,6 +75,8 @@ void foo() {
   // CHECK-CC1-NEXT: COMPLETION: z : [#void#]z(<#int#>)
 
   // RUN: %clang_cc1 -fsyntax-only  -code-completion-patterns -code-completion-at=%s:4:1 -std=gnu++11 %s -o - | FileCheck -check-prefix=CHECK-CC2 %s
+  // CHECK-CC2: COMPLETION: _Coroutine
+  // CHECK-CC2: COMPLETION: Pattern : _Coroutine [#A Coroutine, as defined by concurrency course.#]typename <#name#>
   // CHECK-CC2: COMPLETION: Pattern : asm(<#string-literal#>)
   // CHECK-CC2: COMPLETION: auto
   // CHECK-CC2-NEXT: COMPLETION: bool
@@ -108,7 +110,6 @@ void foo() {
   // CHECK-CC2-NEXT: COMPLETION: thread_local
   // CHECK-CC2-NEXT: COMPLETION: TYPEDEF : TYPEDEF
   // CHECK-CC2-NEXT: COMPLETION: Pattern : typedef <#type#> <#name#>;
-  // CHECK-CC2-NEXT: COMPLETION: Pattern : typename <#name#>
   // CHECK-CC2-NEXT: COMPLETION: Pattern : typeof <#expression#>
   // CHECK-CC2-NEXT: COMPLETION: Pattern : typeof(<#type#>)
   // CHECK-CC2-NEXT: COMPLETION: union
@@ -152,7 +153,6 @@ void foo() {
   // CHECK-CC3-NEXT: COMPLETION: Pattern : template<<#parameters#>>
   // CHECK-CC3-NEXT: COMPLETION: thread_local
   // CHECK-CC3-NEXT: COMPLETION: Pattern : typedef <#type#> <#name#>;
-  // CHECK-CC3-NEXT: COMPLETION: Pattern : typename <#name#>
   // CHECK-CC3-NEXT: COMPLETION: Pattern : typeof <#expression#>
   // CHECK-CC3-NEXT: COMPLETION: Pattern : typeof(<#type#>)
   // CHECK-CC3-NEXT: COMPLETION: union
@@ -201,7 +201,6 @@ void foo() {
   // CHECK-CC4-NEXT: COMPLETION: Pattern : [#bool#]true
   // CHECK-CC4-NEXT: COMPLETION: TYPEDEF : TYPEDEF
   // CHECK-CC4-NEXT: COMPLETION: Pattern : [#std::type_info#]typeid(<#expression-or-type#>)
-  // CHECK-CC4-NEXT: COMPLETION: Pattern : typename <#name#>
   // CHECK-CC4-NEXT: COMPLETION: Pattern : typeof <#expression#>
   // CHECK-CC4-NEXT: COMPLETION: Pattern : typeof(<#type#>)
   // CHECK-CC4-NEXT: COMPLETION: union
@@ -262,8 +261,7 @@ void foo() {
   // CHECK-NO-RTTI: COMPLETION: TYPEDEF : TYPEDEF
   // CHECK-NO-RTTI-NEXT: COMPLETION: Pattern : typedef <#type#> <#name#>;
   // CHECK-NO-RTTI-NOT: typeid
-  // CHECK-NO-RTTI: COMPLETION: Pattern : typename <#name#>
-  // CHECK-NO-RTTI-NEXT: COMPLETION: Pattern : typeof <#expression#>
+  // CHECK-NO-RTTI: COMPLETION: Pattern : typeof <#expression#>
   // CHECK-NO-RTTI-NEXT: COMPLETION: Pattern : typeof(<#type#>)
   // CHECK-NO-RTTI-NEXT: COMPLETION: union
   // CHECK-NO-RTTI-NEXT: COMPLETION: unsigned

--- a/clang/test/CodeCompletion/ordinary-name.cpp
+++ b/clang/test/CodeCompletion/ordinary-name.cpp
@@ -5,6 +5,7 @@ typedef struct t TYPEDEF;
 void foo() {
   int y = 17;
   // RUN: %clang_cc1 -fsyntax-only -fcxx-exceptions -code-completion-patterns -code-completion-at=%s:6:14 -std=gnu++98 %s -o - | FileCheck -check-prefix=CHECK-CC1 %s
+  // CHECK-CC1: COMPLETION: Pattern : _Coroutine [#A Coroutine, as defined by concurrency course.#]typename <#name#>
   // CHECK-CC1: COMPLETION: bool
   // CHECK-CC1-NEXT: COMPLETION: char
   // CHECK-CC1-NEXT: COMPLETION: class
@@ -54,7 +55,6 @@ void foo() {
   // CHECK-CC1: COMPLETION: TYPEDEF : TYPEDEF
   // CHECK-CC1-NEXT: COMPLETION: Pattern : typedef <#type#> <#name#>;
   // CHECK-CC1-NEXT: COMPLETION: Pattern : [#std::type_info#]typeid(<#expression-or-type#>)
-  // CHECK-CC1-NEXT: COMPLETION: Pattern : typename <#name#>
   // CHECK-CC1-NEXT: COMPLETION: Pattern : typeof <#expression#>
   // CHECK-CC1-NEXT: COMPLETION: Pattern : typeof(<#type#>)
   // CHECK-CC1-NEXT: COMPLETION: union

--- a/clang/test/CodeCompletion/ordinary-name.cpp
+++ b/clang/test/CodeCompletion/ordinary-name.cpp
@@ -98,7 +98,6 @@ void foo() {
   // CHECK-CC2-NEXT: COMPLETION: Pattern : template<<#parameters#>>
   // CHECK-CC2-NEXT: COMPLETION: TYPEDEF : TYPEDEF
   // CHECK-CC2-NEXT: COMPLETION: Pattern : typedef <#type#> <#name#>;
-  // CHECK-CC2-NEXT: COMPLETION: Pattern : typename <#name#>
   // CHECK-CC2-NEXT: COMPLETION: Pattern : typeof <#expression#>
   // CHECK-CC2-NEXT: COMPLETION: Pattern : typeof(<#type#>)
   // CHECK-CC2-NEXT: COMPLETION: union
@@ -136,7 +135,6 @@ void foo() {
   // CHECK-CC3-NEXT: COMPLETION: struct
   // CHECK-CC3-NEXT: COMPLETION: Pattern : template<<#parameters#>>
   // CHECK-CC3-NEXT: COMPLETION: Pattern : typedef <#type#> <#name#>;
-  // CHECK-CC3-NEXT: COMPLETION: Pattern : typename <#name#>
   // CHECK-CC3-NEXT: COMPLETION: Pattern : typeof <#expression#>
   // CHECK-CC3-NEXT: COMPLETION: Pattern : typeof(<#type#>)
   // CHECK-CC3-NEXT: COMPLETION: union
@@ -179,7 +177,6 @@ void foo() {
   // CHECK-CC4-NEXT: COMPLETION: Pattern : [#bool#]true
   // CHECK-CC4-NEXT: COMPLETION: TYPEDEF : TYPEDEF
   // CHECK-CC4-NEXT: COMPLETION: Pattern : [#std::type_info#]typeid(<#expression-or-type#>)
-  // CHECK-CC4-NEXT: COMPLETION: Pattern : typename <#name#>
   // CHECK-CC4-NEXT: COMPLETION: Pattern : typeof <#expression#>
   // CHECK-CC4-NEXT: COMPLETION: Pattern : typeof(<#type#>)
   // CHECK-CC4-NEXT: COMPLETION: union
@@ -230,8 +227,7 @@ void foo() {
   // CHECK-NO-RTTI: COMPLETION: TYPEDEF : TYPEDEF
   // CHECK-NO-RTTI-NEXT: COMPLETION: Pattern : typedef <#type#> <#name#>;
   // CHECK-NO-RTTI-NOT: typeid
-  // CHECK-NO-RTTI: COMPLETION: Pattern : typename <#name#>
-  // CHECK-NO-RTTI-NEXT: COMPLETION: Pattern : typeof <#expression#>
+  // CHECK-NO-RTTI: COMPLETION: Pattern : typeof <#expression#>
   // CHECK-NO-RTTI-NEXT: COMPLETION: Pattern : typeof(<#type#>)
   // CHECK-NO-RTTI-NEXT: COMPLETION: union
   // CHECK-NO-RTTI-NEXT: COMPLETION: unsigned


### PR DESCRIPTION
Adds a simple FileCheck test for _Coroutine. For some reason, we broke a previous test but we can figure this out later.

Hopefully this also fixes CI:
https://github.com/FlyingsMarmot/llvm-project/actions/runs/11867203529/job/33074965044#step:7:5562

## Testing:
`ninja -C build check-clang`