### PR TITLE
Support for _Monitor Keyword

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -3768,7 +3768,7 @@ public:
 
   bool isStruct() const { return getTagKind() == TagTypeKind::Struct; }
   bool isInterface() const { return getTagKind() == TagTypeKind::Interface; }
-  bool isClass() const { return getTagKind() == TagTypeKind::Class || getTagKind() == TagTypeKind::Coroutine || getTagKind() == TagTypeKind::Task; }
+  bool isClass() const { return getTagKind() == TagTypeKind::Class || getTagKind() == TagTypeKind::Coroutine || getTagKind() == TagTypeKind::Task || getTagKind() == TagTypeKind::Monitor; }
   bool isUnion() const { return getTagKind() == TagTypeKind::Union; }
   bool isEnum() const { return getTagKind() == TagTypeKind::Enum; }
 

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -6864,6 +6864,9 @@ enum class ElaboratedTypeKeyword {
 
   /// The "Task" keyword also introduces elaborated-type specifier
   Task,
+  
+  /// The "Monitor" keyword also introduces elaborated-type specifier
+  Monitor,
 
   /// No keyword precedes the qualified type name.
   None
@@ -6890,7 +6893,10 @@ enum class TagTypeKind {
   Coroutine,
 
   /// The "Task" keyword.
-  Task
+  Task,
+
+  /// The "_Monitor" keyword
+  Monitor
 };
 
 /// A helper class for Type nodes having an ElaboratedTypeKeyword.

--- a/clang/include/clang/Basic/Specifiers.h
+++ b/clang/include/clang/Basic/Specifiers.h
@@ -81,6 +81,7 @@ namespace clang {
     TST_struct,
     TST_task,              // uC++ Task type
     TST_coroutine,         // uC++ Coroutine type
+    TST_monitor,           // uC++ Monitor type
     TST_class,             // C++ class type
     TST_interface,         // C++ (Microsoft-specific) __interface type
     TST_typename,          // Typedef, C++ class-name or enum name, etc.

--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -339,6 +339,7 @@ KEYWORD(_Generic                    , KEYALL)
 KEYWORD(_Coroutine                  , KEYALL)
 KEYWORD(_Task                       , KEYALL)
 KEYWORD(_When                       , KEYALL)
+KEYWORD(_Monitor                    , KEYALL)
 // Note, C2y removed support for _Imaginary; we retain it as a keyword because
 // 1) it's a reserved identifier, so we're allowed to steal it, 2) there's no
 // good way to specify a keyword in earlier but not later language modes within

--- a/clang/include/clang/Sema/DeclSpec.h
+++ b/clang/include/clang/Sema/DeclSpec.h
@@ -305,6 +305,7 @@ public:
   static const TST TST_class = clang::TST_class;
   static const TST TST_coroutine = clang::TST_coroutine;
   static const TST TST_task = clang::TST_task;
+  static const TST TST_monitor = clang::TST_monitor;
   static const TST TST_typename = clang::TST_typename;
   static const TST TST_typeofType = clang::TST_typeofType;
   static const TST TST_typeofExpr = clang::TST_typeofExpr;
@@ -472,7 +473,7 @@ public:
     return (T == TST_enum || T == TST_struct ||
             T == TST_interface || T == TST_union ||
             T == TST_class || T == TST_coroutine ||
-            T == TST_task);
+            T == TST_task || T == TST_monitor);
   }
   static bool isTransformTypeTrait(TST T) {
     constexpr std::array<TST, 16> Traits = {

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -4363,6 +4363,7 @@ void CXXNameMangler::mangleType(const DependentNameType *T) {
   case ElaboratedTypeKeyword::Class:
   case ElaboratedTypeKeyword::Coroutine:
   case ElaboratedTypeKeyword::Task:
+  case ElaboratedTypeKeyword::Monitor:
   case ElaboratedTypeKeyword::Interface:
     Out << "Ts";
     break;

--- a/clang/lib/AST/MicrosoftMangle.cpp
+++ b/clang/lib/AST/MicrosoftMangle.cpp
@@ -3246,6 +3246,7 @@ void MicrosoftCXXNameMangler::mangleTagTypeKind(TagTypeKind TTK) {
   case TagTypeKind::Class:
   case TagTypeKind::Coroutine:
   case TagTypeKind::Task:
+  case TagTypeKind::Monitor:
     Out << 'V';
     break;
   case TagTypeKind::Enum:

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -3163,6 +3163,8 @@ TypeWithKeyword::getKeywordForTypeSpec(unsigned TypeSpec) {
     return ElaboratedTypeKeyword::Coroutine;
   case TST_task:
     return ElaboratedTypeKeyword::Task;
+  case TST_monitor:
+    return ElaboratedTypeKeyword::Monitor;
   case TST_class:
     return ElaboratedTypeKeyword::Class;
   case TST_struct:
@@ -3183,6 +3185,8 @@ TypeWithKeyword::getTagTypeKindForTypeSpec(unsigned TypeSpec) {
     return TagTypeKind::Coroutine;
   case TST_task: 
     return TagTypeKind::Task;
+  case TST_monitor:
+    return TagTypeKind::Monitor;
   case TST_class:
     return TagTypeKind::Class;
   case TST_struct:
@@ -3207,6 +3211,8 @@ TypeWithKeyword::getKeywordForTagTypeKind(TagTypeKind Kind) {
     return ElaboratedTypeKeyword::Coroutine;
   case TagTypeKind::Task:
     return ElaboratedTypeKeyword::Task;
+  case TagTypeKind::Monitor:
+    return ElaboratedTypeKeyword::Monitor;
   case TagTypeKind::Struct:
     return ElaboratedTypeKeyword::Struct;
   case TagTypeKind::Interface:
@@ -3228,6 +3234,8 @@ TypeWithKeyword::getTagTypeKindForKeyword(ElaboratedTypeKeyword Keyword) {
     return TagTypeKind::Coroutine;
   case ElaboratedTypeKeyword::Task:
     return TagTypeKind::Task;
+  case ElaboratedTypeKeyword::Monitor:
+    return TagTypeKind::Monitor;
   case ElaboratedTypeKeyword::Struct:
     return TagTypeKind::Struct;
   case ElaboratedTypeKeyword::Interface:
@@ -3252,6 +3260,7 @@ TypeWithKeyword::KeywordIsTagTypeKind(ElaboratedTypeKeyword Keyword) {
   case ElaboratedTypeKeyword::Class:
   case ElaboratedTypeKeyword::Coroutine:
   case ElaboratedTypeKeyword::Task:
+  case ElaboratedTypeKeyword::Monitor:
   case ElaboratedTypeKeyword::Struct:
   case ElaboratedTypeKeyword::Interface:
   case ElaboratedTypeKeyword::Union:
@@ -3281,6 +3290,8 @@ StringRef TypeWithKeyword::getKeywordName(ElaboratedTypeKeyword Keyword) {
     return "_Coroutine";
   case ElaboratedTypeKeyword::Task:
     return "_Task";
+  case ElaboratedTypeKeyword::Monitor:
+    return "_Monitor";
   }
 
   llvm_unreachable("Unknown elaborated type keyword.");

--- a/clang/lib/Index/IndexSymbol.cpp
+++ b/clang/lib/Index/IndexSymbol.cpp
@@ -114,6 +114,7 @@ SymbolInfo index::getSymbolInfo(const Decl *D) {
     case TagTypeKind::Class:
     case TagTypeKind::Coroutine:
     case TagTypeKind::Task:
+    case TagTypeKind::Monitor:
       Info.Kind = SymbolKind::Class;
       Info.Lang = SymbolLanguage::CXX;
       break;

--- a/clang/lib/Index/USRGeneration.cpp
+++ b/clang/lib/Index/USRGeneration.cpp
@@ -531,6 +531,7 @@ void USRGenerator::VisitTagDecl(const TagDecl *D) {
       case TagTypeKind::Class:
       case TagTypeKind::Coroutine:
       case TagTypeKind::Task:
+      case TagTypeKind::Monitor:
       case TagTypeKind::Struct:
         Out << "@ST";
         break;
@@ -550,6 +551,7 @@ void USRGenerator::VisitTagDecl(const TagDecl *D) {
       case TagTypeKind::Class:
       case TagTypeKind::Coroutine:
       case TagTypeKind::Task:
+      case TagTypeKind::Monitor:
       case TagTypeKind::Struct:
         Out << "@SP";
         break;
@@ -569,6 +571,7 @@ void USRGenerator::VisitTagDecl(const TagDecl *D) {
     case TagTypeKind::Class:
     case TagTypeKind::Coroutine:
     case TagTypeKind::Task:
+    case TagTypeKind::Monitor:
     case TagTypeKind::Struct:
       Out << "@S";
       break;

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -3124,6 +3124,8 @@ bool Parser::ParseImplicitInt(DeclSpec &DS, CXXScopeSpec *SS,
         TagName="coroutine" ; FixitTagName = "coroutine "; TagKind=tok::kw__Coroutine; break;
       case DeclSpec::TST_task:
         TagName="task" ; FixitTagName = "task "; TagKind=tok::kw__Task; break;
+      case DeclSpec::TST_monitor:
+        TagName="monitor" ; FixitTagName = "monitor "; TagKind=tok::kw__Monitor; break;
     }
 
     if (TagName) {

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -4692,6 +4692,7 @@ void Parser::ParseDeclarationSpecifiers(
     case tok::kw_class:
     case tok::kw__Coroutine:
     case tok::kw__Task:
+    case tok::kw__Monitor:
     case tok::kw_struct:
     case tok::kw___interface:
     case tok::kw_union: {

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -1730,9 +1730,8 @@ void Parser::ParseClassSpecifier(tok::TokenKind TagTokKind,
     TagType = DeclSpec::TST_coroutine;
   else if (TagTokKind == tok::kw__Task)
       TagType = DeclSpec::TST_task;
-  else if (TagTokKind == tok::kw__Monitor) {
-    TagType = DeclSpec::TST_monitor;
-  }
+  else if (TagTokKind == tok::kw__Monitor)
+      TagType = DeclSpec::TST_monitor;
     
   else {
     assert(TagTokKind == tok::kw_union && "Not a class specifier");

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -1730,6 +1730,9 @@ void Parser::ParseClassSpecifier(tok::TokenKind TagTokKind,
     TagType = DeclSpec::TST_coroutine;
   else if (TagTokKind == tok::kw__Task)
       TagType = DeclSpec::TST_task;
+  else if (TagTokKind == tok::kw__Monitor) {
+    TagType = DeclSpec::TST_monitor;
+  }
     
   else {
     assert(TagTokKind == tok::kw_union && "Not a class specifier");
@@ -3763,7 +3766,8 @@ void Parser::ParseCXXMemberSpecification(SourceLocation RecordLoc,
   assert((TagType == DeclSpec::TST_struct ||
           TagType == DeclSpec::TST_interface ||
           TagType == DeclSpec::TST_union || TagType == DeclSpec::TST_class ||
-          TagType == DeclSpec::TST_coroutine || TagType == DeclSpec::TST_task) &&
+          TagType == DeclSpec::TST_coroutine || TagType == DeclSpec::TST_task || 
+          TagType == DeclSpec::TST_monitor) &&
          "Invalid TagType!");
 
   llvm::TimeTraceScope TimeScope("ParseClass", [&]() {
@@ -3940,7 +3944,7 @@ void Parser::ParseCXXMemberSpecification(SourceLocation RecordLoc,
   // are public by default.
   // HLSL: In HLSL members of a class are public by default.
   AccessSpecifier CurAS;
-  if ((TagType == DeclSpec::TST_class || TagType == DeclSpec::TST_coroutine || TagType == DeclSpec::TST_task) && !getLangOpts().HLSL)
+  if ((TagType == DeclSpec::TST_class || TagType == DeclSpec::TST_coroutine || TagType == DeclSpec::TST_task || TagType == DeclSpec::TST_monitor) && !getLangOpts().HLSL)
     CurAS = AS_private;
   else
     CurAS = AS_public;

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -1164,6 +1164,7 @@ Parser::DeclGroupPtrTy Parser::ParseDeclOrFunctionDefInternal(
       case DeclSpec::TST_class:
       case DeclSpec::TST_coroutine:
       case DeclSpec::TST_task:
+      case DeclSpec::TST_monitor:
         return 5;
       case DeclSpec::TST_struct:
         return 6;

--- a/clang/lib/Sema/DeclSpec.cpp
+++ b/clang/lib/Sema/DeclSpec.cpp
@@ -352,6 +352,7 @@ bool Declarator::isDeclarationOfFunction() const {
     case TST_class:
     case TST_coroutine:
     case TST_task:
+    case TST_monitor:
     case TST_decimal128:
     case TST_decimal32:
     case TST_decimal64:
@@ -589,6 +590,7 @@ const char *DeclSpec::getSpecifierName(DeclSpec::TST T,
   case DeclSpec::TST_class:       return "class";
   case DeclSpec::TST_coroutine:   return "coroutine";
   case DeclSpec::TST_task:        return "task";
+  case DeclSpec::TST_monitor:     return "monitor";
   case DeclSpec::TST_union:       return "union";
   case DeclSpec::TST_struct:      return "struct";
   case DeclSpec::TST_interface:   return "__interface";

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -1821,6 +1821,7 @@ static void AddTypeSpecifierResults(const LangOptions &LangOpts,
     Results.AddResult(Result("class", CCP_Type));
     Results.AddResult(Result("_Coroutine", CCP_Type));
     Results.AddResult(Result("_Task", CCP_Type));
+    Results.AddResult(Result("_Monitor", CCP_Type));
     Results.AddResult(Result("wchar_t", CCP_Type));
 
     // typename name
@@ -2035,8 +2036,8 @@ static const char *GetCompletionTypeString(QualType T, ASTContext &Context,
           case TagTypeKind::Interface:
             return "__interface <anonymous>";
           case TagTypeKind::Class:
-            return "class <anonymous>";
           case TagTypeKind::Coroutine:
+          case TagTypeKind::Monitor:
             return "class <anonymous>";
           case TagTypeKind::Task:
             return "Task <anonymous>";
@@ -4207,6 +4208,7 @@ CXCursorKind clang::getCursorKindForDecl(const Decl *D) {
       case TagTypeKind::Class:
       case TagTypeKind::Coroutine:
       case TagTypeKind::Task:
+      case TagTypeKind::Monitor:
         return CXCursor_ClassDecl;
       case TagTypeKind::Union:
         return CXCursor_UnionDecl;
@@ -4561,7 +4563,8 @@ void SemaCodeCompletion::CodeCompleteDeclSpec(Scope *S, DeclSpec &DS,
         (DS.getTypeSpecType() == DeclSpec::TST_class ||
          DS.getTypeSpecType() == DeclSpec::TST_struct || 
          DS.getTypeSpecType() == DeclSpec::TST_coroutine ||
-         DS.getTypeSpecType() == DeclSpec::TST_task))
+         DS.getTypeSpecType() == DeclSpec::TST_task ||
+         DS.getTypeSpecType() == DeclSpec::TST_monitor))
       Results.AddResult("final");
 
     if (AllowNonIdentifiers) {
@@ -5953,6 +5956,7 @@ void SemaCodeCompletion::CodeCompleteTag(Scope *S, unsigned TagSpec) {
   case DeclSpec::TST_class:
   case DeclSpec::TST_coroutine:
   case DeclSpec::TST_task:
+  case DeclSpec::TST_monitor:
   case DeclSpec::TST_interface:
     Filter = &ResultBuilder::IsClassOrStruct;
     ContextKind = CodeCompletionContext::CCC_ClassOrStructTag;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -660,6 +660,8 @@ DeclSpec::TST Sema::isTagName(IdentifierInfo &II, Scope *S) {
         return DeclSpec::TST_coroutine;
       case TagTypeKind::Task:
         return DeclSpec::TST_task;
+      case TagTypeKind::Monitor:
+        return DeclSpec::TST_monitor;
       case TagTypeKind::Enum:
         return DeclSpec::TST_enum;
       }
@@ -825,6 +827,7 @@ static bool isTagTypeWithMissingTag(Sema &SemaRef, LookupResult &Result,
     switch (Tag->getTagKind()) {
     case TagTypeKind::Coroutine:
     case TagTypeKind::Task:
+    case TagTypeKind::Monitor:
     case TagTypeKind::Class:
       FixItTagName = "class ";
       break;
@@ -4997,6 +5000,7 @@ static unsigned GetDiagnosticTypeSpecifierID(const DeclSpec &DS) {
   case DeclSpec::TST_class:
   case DeclSpec::TST_coroutine:
   case DeclSpec::TST_task:
+  case DeclSpec::TST_monitor:
     return 0;
   case DeclSpec::TST_struct:
     return 1;
@@ -5029,6 +5033,7 @@ Decl *Sema::ParsedFreeStandingDeclSpec(Scope *S, AccessSpecifier AS,
   if (DS.getTypeSpecType() == DeclSpec::TST_class ||
       DS.getTypeSpecType() == DeclSpec::TST_coroutine ||
       DS.getTypeSpecType() == DeclSpec::TST_task ||
+      DS.getTypeSpecType() == DeclSpec::TST_monitor ||
       DS.getTypeSpecType() == DeclSpec::TST_struct ||
       DS.getTypeSpecType() == DeclSpec::TST_interface ||
       DS.getTypeSpecType() == DeclSpec::TST_union ||
@@ -5255,6 +5260,7 @@ Decl *Sema::ParsedFreeStandingDeclSpec(Scope *S, AccessSpecifier AS,
     if (TypeSpecType == DeclSpec::TST_class ||
         TypeSpecType == DeclSpec::TST_coroutine ||
         TypeSpecType == DeclSpec::TST_task ||
+        TypeSpecType == DeclSpec::TST_monitor ||
         TypeSpecType == DeclSpec::TST_struct ||
         TypeSpecType == DeclSpec::TST_interface ||
         TypeSpecType == DeclSpec::TST_union ||
@@ -16813,6 +16819,7 @@ TypedefDecl *Sema::ParseTypedefDecl(Scope *S, Declarator &D, QualType T,
   case TST_union:
   case TST_coroutine:
   case TST_task:
+  case TST_monitor:
   case TST_class: {
     TagDecl *tagFromDeclSpec = cast<TagDecl>(D.getDeclSpec().getRepAsDecl());
     setTagNameForLinkagePurposes(tagFromDeclSpec, NewTD);
@@ -16920,6 +16927,7 @@ Sema::NonTagKind Sema::getNonTagTypeDeclKind(const Decl *PrevDecl,
   case TagTypeKind::Class:
   case TagTypeKind::Coroutine:
   case TagTypeKind::Task:
+  case TagTypeKind::Monitor:
     return getLangOpts().CPlusPlus ? NTK_NonClass : NTK_NonStruct;
   case TagTypeKind::Union:
     return NTK_NonUnion;

--- a/clang/lib/Sema/SemaTemplateVariadic.cpp
+++ b/clang/lib/Sema/SemaTemplateVariadic.cpp
@@ -992,6 +992,7 @@ bool Sema::containsUnexpandedParameterPacks(Declarator &D) {
   case TST_class:
   case TST_coroutine:
   case TST_task:
+  case TST_monitor:
   case TST_auto:
   case TST_auto_type:
   case TST_decltype_auto:

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -1197,6 +1197,7 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
   case DeclSpec::TST_class:
   case DeclSpec::TST_coroutine:
   case DeclSpec::TST_task:
+  case DeclSpec::TST_monitor:
   case DeclSpec::TST_enum:
   case DeclSpec::TST_union:
   case DeclSpec::TST_struct:
@@ -3247,6 +3248,7 @@ static QualType GetDeclSpecTypeForDeclarator(TypeProcessingState &state,
         case TagTypeKind::Class:
         case TagTypeKind::Coroutine:
         case TagTypeKind::Task:
+        case TagTypeKind::Monitor:
           Error = 5; /* Class member */
           break;
         case TagTypeKind::Interface:

--- a/clang/tools/libclang/CIndexCXX.cpp
+++ b/clang/tools/libclang/CIndexCXX.cpp
@@ -69,6 +69,7 @@ enum CXCursorKind clang_getTemplateCursorKind(CXCursor C) {
       case TagTypeKind::Class:
       case TagTypeKind::Coroutine:
       case TagTypeKind::Task:
+      case TagTypeKind::Monitor:
         return CXCursor_ClassDecl;
       case TagTypeKind::Union:
         return CXCursor_UnionDecl;

--- a/clang/utils/ClangVisualizers/clang.natvis
+++ b/clang/utils/ClangVisualizers/clang.natvis
@@ -854,7 +854,7 @@ For later versions of Visual Studio, no setup is required-->
     <DisplayString IncludeView="extra" Condition="TypeSpecType == TST_typeofExpr || TypeSpecType == TST_decltype">
       , [{ExprRep}]
     </DisplayString>
-    <DisplayString IncludeView="extra" Condition="TypeSpecType == TST_enum || TypeSpecType == TST_struct || TypeSpecType == TST_interface || TypeSpecType == TST_union || TypeSpecType == TST_class || TypeSpecType == TST_coroutine || TypeSpecType == TST_task">
+    <DisplayString IncludeView="extra" Condition="TypeSpecType == TST_enum || TypeSpecType == TST_struct || TypeSpecType == TST_interface || TypeSpecType == TST_union || TypeSpecType == TST_class || TypeSpecType == TST_coroutine || TypeSpecType == TST_task || TypeSpecType == TST_monitor">
       , [{DeclRep}]
     </DisplayString>
     <DisplayString IncludeView="extra"></DisplayString>
@@ -868,7 +868,7 @@ For later versions of Visual Studio, no setup is required-->
       <Item Name="ExprRep" Condition="TypeSpecType == TST_typeofExpr || TypeSpecType == TST_decltype">
         ExprRep
       </Item>
-      <Item Name="DeclRep" Condition="TypeSpecType == TST_enum || TypeSpecType == TST_struct || TypeSpecType == TST_interface || TypeSpecType == TST_union || TypeSpecType == TST_class || TypeSpecType == TST_coroutine || TypeSpecType == TST_task">
+      <Item Name="DeclRep" Condition="TypeSpecType == TST_enum || TypeSpecType == TST_struct || TypeSpecType == TST_interface || TypeSpecType == TST_union || TypeSpecType == TST_class || TypeSpecType == TST_coroutine || TypeSpecType == TST_task || TypeSpecType == TST_monitor">
         DeclRep
       </Item>
 


### PR DESCRIPTION
In this PR, we are adding support for the `_Monitor` keyword.

Changeset Validity:

![Screenshot 2025-02-25 at 6 43 29 PM](https://github.com/user-attachments/assets/f3a1482d-e4c8-4694-b3a7-66d2dc0ee7c6)
