### PR TITLE
Else keyword

### DIFF
--- a/clang/include/clang/Basic/TokenKinds.def
+++ b/clang/include/clang/Basic/TokenKinds.def
@@ -343,6 +343,7 @@ KEYWORD(_Task                       , KEYALL)
 KEYWORD(_Exception                  , KEYALL)
 KEYWORD(_When                       , KEYALL)
 KEYWORD(_Monitor                    , KEYALL)
+KEYWORD(_Else                       , KEYALL)
 // Note, C2y removed support for _Imaginary; we retain it as a keyword because
 // 1) it's a reserved identifier, so we're allowed to steal it, 2) there's no
 // good way to specify a keyword in earlier but not later language modes within

--- a/clang/include/clang/Sema/SemaCodeCompletion.h
+++ b/clang/include/clang/Sema/SemaCodeCompletion.h
@@ -151,6 +151,7 @@ public:
                               llvm::ArrayRef<Expr *> InitExprs,
                               const Designation &D);
   void CodeCompleteAfterIf(Scope *S, bool IsBracedThen);
+  void CodeCompleteAfterAccept(Scope *S, bool IsBracedThen);
 
   void CodeCompleteQualifiedId(Scope *S, CXXScopeSpec &SS, bool EnteringContext,
                                bool IsUsingDeclaration, QualType BaseType,

--- a/clang/lib/Parse/ParseStmt.cpp
+++ b/clang/lib/Parse/ParseStmt.cpp
@@ -1647,7 +1647,7 @@ StmtResult Parser::ParseAcceptStatement(SourceLocation *TrailingElseLoc) {
   if (Tok.is(tok::pipepipe)) {
     Tok.setKind(tok::kw_or);
   }
-  if (Tok.is(tok::kw_or)) {
+  if (Tok.is(tok::kw_or) || Tok.is(tok::kw__Else)) {
     if (TrailingElseLoc)
       *TrailingElseLoc = Tok.getLocation();
 
@@ -1687,7 +1687,7 @@ StmtResult Parser::ParseAcceptStatement(SourceLocation *TrailingElseLoc) {
     InnerScope.Exit();
   } else if (Tok.is(tok::code_completion)) {
     cutOffParsing();
-    Actions.CodeCompletion().CodeCompleteAfterIf(getCurScope(), IsBracedThen);
+    Actions.CodeCompletion().CodeCompleteAfterAccept(getCurScope(), IsBracedThen);
     return StmtError();
   } else if (InnerStatementTrailingElseLoc.isValid()) {
     Diag(InnerStatementTrailingElseLoc, diag::warn_dangling_else);
@@ -2001,7 +2001,11 @@ StmtResult Parser::ParseWhenStatement(SourceLocation *TrailingElseLoc) {
 
   // IdentifierInfo *VarName = Tok.getIdentifierInfo();
   // SourceLocation VarLoc = ConsumeToken(); // Eat the variable name
-
+  SourceLocation ElseLoc;
+  if (Tok.is(tok::kw__Else)) {
+    ElseLoc = ConsumeToken();
+  }
+  
   if (Tok.isNot(tok::l_brace))
     return StmtError(Diag(Tok, diag::err_expected) << tok::l_brace);
 
@@ -2009,7 +2013,6 @@ StmtResult Parser::ParseWhenStatement(SourceLocation *TrailingElseLoc) {
 
   if(Block.isInvalid())
     return Block;
-
   IdentifierInfo *VarName = nullptr;
   SourceLocation VarLoc;
   bool IsAccept = false;

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -6745,6 +6745,80 @@ void SemaCodeCompletion::CodeCompleteAfterIf(Scope *S, bool IsBracedThen) {
                             Results.size());
 }
 
+void SemaCodeCompletion::CodeCompleteAfterAccept(Scope *S, bool IsBracedThen) {
+  ResultBuilder Results(SemaRef, CodeCompleter->getAllocator(),
+                        CodeCompleter->getCodeCompletionTUInfo(),
+                        mapCodeCompletionContext(SemaRef, PCC_Statement));
+  Results.setFilter(&ResultBuilder::IsOrdinaryName);
+  Results.EnterNewScope();
+
+  CodeCompletionDeclConsumer Consumer(Results, SemaRef.CurContext);
+  SemaRef.LookupVisibleDecls(S, Sema::LookupOrdinaryName, Consumer,
+                             CodeCompleter->includeGlobals(),
+                             CodeCompleter->loadExternal());
+
+  AddOrdinaryNameResults(PCC_Statement, S, SemaRef, Results);
+
+  // "else" block, but for uC++ we've got a bit more stuff -> or _Accept, _Else, _Else _Accept
+  CodeCompletionBuilder Builder(Results.getAllocator(),
+                                Results.getCodeCompletionTUInfo());
+
+  auto AddElseBodyPattern = [&] {
+    if (IsBracedThen) {
+      Builder.AddChunk(CodeCompletionString::CK_HorizontalSpace);
+      Builder.AddChunk(CodeCompletionString::CK_LeftBrace);
+      Builder.AddChunk(CodeCompletionString::CK_VerticalSpace);
+      Builder.AddPlaceholderChunk("statements");
+      Builder.AddChunk(CodeCompletionString::CK_VerticalSpace);
+      Builder.AddChunk(CodeCompletionString::CK_RightBrace);
+    } else {
+      Builder.AddChunk(CodeCompletionString::CK_VerticalSpace);
+      Builder.AddChunk(CodeCompletionString::CK_HorizontalSpace);
+      Builder.AddPlaceholderChunk("statement");
+      Builder.AddChunk(CodeCompletionString::CK_SemiColon);
+    }
+  };
+  Builder.AddTypedTextChunk("_Else");
+  if (Results.includeCodePatterns())
+    AddElseBodyPattern();
+  Results.AddResult(Builder.TakeString());
+
+  // "else _Accept" block
+  Builder.AddTypedTextChunk("_Else _Accept");
+  Builder.AddChunk(CodeCompletionString::CK_HorizontalSpace);
+  Builder.AddChunk(CodeCompletionString::CK_LeftParen);
+  Builder.AddPlaceholderChunk("expression");
+  Builder.AddChunk(CodeCompletionString::CK_RightParen);
+  if (Results.includeCodePatterns()) {
+    AddElseBodyPattern();
+  }
+  Results.AddResult(Builder.TakeString());
+
+  // "or _Accept" block
+  Builder.AddTypedTextChunk("or _Accept");
+  Builder.AddChunk(CodeCompletionString::CK_HorizontalSpace);
+  Builder.AddChunk(CodeCompletionString::CK_LeftParen);
+  Builder.AddPlaceholderChunk("expression");
+  Builder.AddChunk(CodeCompletionString::CK_RightParen);
+  if (Results.includeCodePatterns()) {
+    AddElseBodyPattern();
+  }
+  Results.AddResult(Builder.TakeString());
+
+  Results.ExitScope();
+
+  if (S->getFnParent())
+    AddPrettyFunctionResults(getLangOpts(), Results);
+
+  if (CodeCompleter->includeMacros())
+    AddMacroResults(SemaRef.PP, Results, CodeCompleter->loadExternal(), false);
+
+  HandleCodeCompleteResults(&SemaRef, CodeCompleter,
+                            Results.getCompletionContext(), Results.data(),
+                            Results.size());
+}
+
+
 void SemaCodeCompletion::CodeCompleteQualifiedId(Scope *S, CXXScopeSpec &SS,
                                                  bool EnteringContext,
                                                  bool IsUsingDeclaration,

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -2383,9 +2383,11 @@ AddOrdinaryNameResults(SemaCodeCompletion::ParserCompletionContext CCC,
     if (Results.includeCodePatterns()) {
       // _When (condition) { statements }
       Builder.AddTypedTextChunk("_When");
+      Builder.AddChunk(CodeCompletionString::CK_HorizontalSpace);
       Builder.AddChunk(CodeCompletionString::CK_LeftParen);
       Builder.AddPlaceholderChunk("condition");
       Builder.AddChunk(CodeCompletionString::CK_RightParen);
+      Builder.AddChunk(CodeCompletionString::CK_HorizontalSpace);
       Builder.AddChunk(CodeCompletionString::CK_LeftBrace);
       Builder.AddChunk(CodeCompletionString::CK_VerticalSpace);
       Builder.AddPlaceholderChunk("statements");


### PR DESCRIPTION
- Cleaned up ParseAcceptStaement
- Added _Else keyword
- modified `ParseWhenStatement` to conditionally parse subsequent block scope `{}`, and `_Else`
- added more auto code complete for _Accept patterns with the _Else statement being added
Some samples:
<img width="453" alt="image" src="https://github.com/user-attachments/assets/51c12c0e-f4a5-4f91-a885-717f376e37b7" />
 
<img width="578" alt="image" src="https://github.com/user-attachments/assets/5c956af5-777a-4d28-8f16-6952ff82a5ad" />
