### PR TITLE
Support uCondition

### DIFF
--- a/clang-tools-extra/clangd/CodeComplete.cpp
+++ b/clang-tools-extra/clangd/CodeComplete.cpp
@@ -307,9 +307,17 @@ struct CompletionCandidate {
           return std::nullopt;
     }
     Symbol::IncludeDirective Directive = insertionDirective(Opts);
-    for (const auto &Inc : RankedIncludeHeaders)
-      if ((Inc.Directive & Directive) != 0)
+
+    // This file is appended to our include path but we NEVER want to auto import it
+    // This (sort of) mimics the import injection actually done by uC++
+    const auto ucppIgnorePath = "source/src/kernel/uC%2B%2B.h";
+
+    for (const auto &Inc : RankedIncludeHeaders) {
+      if ( ((Inc.Directive & Directive) != 0) && !Inc.Header.contains(ucppIgnorePath)) {
         return Inc.Header;
+      }
+    }
+
     return std::nullopt;
   }
 

--- a/clang-tools-extra/clangd/CompileCommands.cpp
+++ b/clang-tools-extra/clangd/CompileCommands.cpp
@@ -206,12 +206,19 @@ void CommandMangler::operator()(tooling::CompileCommand &Command,
   trace::Span S("AdjustCompileFlags");
   
   // Add uCPP code to the include path
-  
   std::filesystem::path extensionDirPath = std::filesystem::path(clang::clangd::ClangdBinaryPath).parent_path();
   std::filesystem::path ucppIncludePath = (extensionDirPath / "uCPP/source/src/library");
-
   Cmd.push_back("-I" + ucppIncludePath.string());
-  Cmd.push_back("-ferror-limit=0"); //"-ferror-limit=0"
+  
+  // Disable error limit
+  // This is kind of corner cutting but this helps us to ignore error diagnostics present in uC++ files
+  Cmd.push_back("-ferror-limit=0");
+
+  // "mock" the import injection done by uC++
+  std::filesystem::path ucppKernelHeaderPath = (extensionDirPath / "uCPP/source/src/kernel/uC++.h");
+  Cmd.push_back("-include");
+  Cmd.push_back(ucppKernelHeaderPath.string());
+
 
   // Most of the modifications below assumes the Cmd starts with a driver name.
   // We might consider injecting a generic driver name like "cc" or "c++", but


### PR DESCRIPTION
What I did
- Don't allow auto imports for any path with the `ucppIgnorePath` string. Auto imports here refers to like how when you type vector it may automatically import / include it for you
- Hardcode an include flag for `source/src/kernel/uC++.h`

Why I did this
- For some structures like `uCondition` (benches), you work with these but don't actually need to actually import anything to work with them
- The uC++ build system injects these imports during build, so that's how the file "knows" where it comes from and what it is during compilation
- I'm essentially mocking this injection by always including it but then preventing it from being auto imported. So the file is always in scope

![image](https://github.com/user-attachments/assets/7927fd94-37da-47b4-a1f5-78ebd6997216)
